### PR TITLE
Type optional key property in Meta type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export function createOperationsHandler<Options>(fn: OperationHandler<Options>) 
 export type Meta = Record<string, any> & {
   event: string
   collection: string
+  key?: string
   keys: string[]
 }
 export type HookContext<T = unknown> = AccountableContext & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,6 @@ export function createOperationsHandler<Options>(fn: OperationHandler<Options>) 
 export type Meta = Record<string, any> & {
   event: string
   collection: string
-  key?: string
   keys: string[]
 }
 export type HookContext<T = unknown> = AccountableContext & {
@@ -86,10 +85,14 @@ export function defineHook(fn: HookConfig): DirectusHookConfig {
       filter: (event: string, handler: FilterHandler) => {
         register.filter(event, async (payload, meta, context) => {
           try {
+            let keys = meta.keys ?? []
+            if (meta.key) {
+              keys.push(meta.key)
+            }
             return await handler(
               {
                 ...meta,
-                keys: meta.keys ?? [],
+                keys,
               } as Meta,
               {
                 ...hookContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,14 +85,10 @@ export function defineHook(fn: HookConfig): DirectusHookConfig {
       filter: (event: string, handler: FilterHandler) => {
         register.filter(event, async (payload, meta, context) => {
           try {
-            let keys = meta.keys ?? []
-            if (meta.key) {
-              keys.push(meta.key)
-            }
             return await handler(
               {
                 ...meta,
-                keys,
+                keys: meta.keys ?? [],
               } as Meta,
               {
                 ...hookContext,
@@ -109,10 +105,14 @@ export function defineHook(fn: HookConfig): DirectusHookConfig {
         register.action(event, (meta, context) => {
           async function run() {
             try {
+              let keys = meta.keys ?? []
+              if (meta.key) {
+                keys.push(meta.key)
+              }
               await handler(
                 {
                   ...meta,
-                  keys: meta.keys ?? [],
+                  keys,
                 } as Meta,
                 {
                   ...hookContext,


### PR DESCRIPTION
Some Filter and Action events use key: string instead of keys: string[] in Meta object.