### PR TITLE
Enhance items.delete filter to read keys in Meta instead of from the payload.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,10 +84,13 @@ export function defineHook(fn: HookConfig): DirectusHookConfig {
     fn({
       filter: (event: string, handler: FilterHandler) => {
         register.filter(event, async (payload, meta, context) => {
-          let keys = meta.keys ?? []
           try {
+            let keys = []
+            if (meta.keys) {
+              keys = meta.keys
+            }
             if (meta.event.endsWith('.items.delete')) {
-              keys = payload
+              keys = payload as string[]
             }
             return await handler(
               {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,14 +84,15 @@ export function defineHook(fn: HookConfig): DirectusHookConfig {
     fn({
       filter: (event: string, handler: FilterHandler) => {
         register.filter(event, async (payload, meta, context) => {
+          let keys = meta.keys ?? []
           try {
-            if (meta.event.endsWith('items.delete')) {
-              meta.keys = payload
+            if (meta.event.endsWith('.items.delete')) {
+              keys = payload
             }
             return await handler(
               {
                 ...meta,
-                keys: meta.keys ?? [],
+                keys: keys,
               } as Meta,
               {
                 ...hookContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,9 @@ export function defineHook(fn: HookConfig): DirectusHookConfig {
       filter: (event: string, handler: FilterHandler) => {
         register.filter(event, async (payload, meta, context) => {
           try {
+            if (meta.event.endsWith('items.delete')) {
+              meta.keys = payload
+            }
             return await handler(
               {
                 ...meta,
@@ -143,25 +146,16 @@ export function readTriggerKeys(context: OperationContext) {
   return ((context.data as any).$trigger.keys as string[]) ?? []
 }
 
-type PayloadSchema =
-  | z.AnyZodObject
-  | z.ZodUnion<[z.AnyZodObject, ...z.AnyZodObject[]]>
-  | z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodNumber]>, 'many'>
+type PayloadSchema = z.AnyZodObject | z.ZodUnion<[z.AnyZodObject, ...z.AnyZodObject[]]>
 export function readTriggerPayload<T extends PayloadSchema>(context: OperationContext, schema: T) {
   if (schema instanceof z.ZodObject) {
     return schema.passthrough().parse((context.data as any).$trigger.payload) as z.infer<T>
-  }
-  if (schema instanceof z.ZodArray) {
-    return schema.parse((context.data as any).$trigger.payload) as z.infer<T>
   }
   return z.union(schema.options.map((option) => option.passthrough()) as any).parse((context.data as any).$trigger.payload) as z.infer<T>
 }
 export function readHookPayload<T extends PayloadSchema>(context: HookContext, schema: T) {
   if (schema instanceof z.ZodObject) {
     return schema.passthrough().parse(context._payload) as z.infer<T>
-  }
-  if (schema instanceof z.ZodArray) {
-    return schema.parse(context._payload) as z.infer<T>
   }
   return z.union(schema.options.map((option) => option.passthrough()) as any).parse(context._payload) as z.infer<T>
 }


### PR DESCRIPTION
The '*.items.delete' filter receives the list of keys in the payload and not in the meta.keys object.